### PR TITLE
added dataset metadata and conda environment installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,14 @@ The code to train source separation models on the WSJ0-mix dataset is available 
 - `train.py`: code to launch to train the systems. It manages the configurations and the exeriments saving.
 - `utils.py`: various utilitaries
 - `config_dprnn.py`: configuration file for DPRNN with each configuration for the experiments conducted in the paper.
-- `config_sudo.py`: same with SudoRm-Rf 
+- `config_sudo.py`: same with SudoRm-Rf
+- `update_metadata.py`: script for updating the path in the metadata of the WSJ0-mix dataset.
 
 ### Environment
 
 To install the dependencies, please use the following commands:
 ```
+cd source_separation
 conda create -n annealed_mcl python=3.8
 conda activate annealed_mcl
 conda install pytorch==2.0.0 pytorch-cuda==11.7 -c pytorch -c nvidia -y

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ pip install -r requirements.txt
 
 ### Data preparation
 
-Metadata for the WJS0-mix dataset are provided. In order to reproduce our experiments, download the wsj0-mix dataset from the [official WSJ0 website](https://catalog.ldc.upenn.edu/LDC93S6A). Once you have access to the WSJ0 data, you can generate the mixtures using the tools provided in [this repository](https://github.com/kaituoxu/Conv-TasNet) (see the "Usage" section in the README). We provide the metadata for mixtures from 2 to 5 speakers at the following [url](https://drive.google.com/drive/folders/1i4S17O5h-k5YNCtoOj53osuzgDNYH6pN?usp=sharing). Download the `data` folder from this url and place in the `./source_separation` folder. 
+Metadata for the WJS0-mix dataset is provided. To reproduce our experiments, download the wsj0-mix dataset from the [official WSJ0 website](https://catalog.ldc.upenn.edu/LDC93S6A). Once you have access to the WSJ0 data, you can generate the mixtures using the tools provided in [this repository](https://github.com/kaituoxu/Conv-TasNet) (see the "Usage" section in the README). We provide the metadata for mixtures from 2 to 5 speakers at the following [url](https://drive.google.com/drive/folders/1i4S17O5h-k5YNCtoOj53osuzgDNYH6pN?usp=sharing). Download the `data` folder from this url and place it in the `./source_separation` folder. 
 
 Finally, update the downloaded metadata audio path to specify the root folder of the WSJ0-mix dataset with the following command:
 ```
@@ -174,22 +174,6 @@ python update_metadata.py /wsj0-mix/root/path
 To train a model:
 ```
 python train.py --conf_id 001 --backbone dprnn
-```
-
-### Main dependencies
-
-```
-# Name                    Version      
-asteroid                  0.6.1.dev0               
-numpy                     1.24.4                   
-pandas                    2.0.3                   
-pot                       0.9.3                   
-python                    3.8.18              
-pytorch-lightning         1.7.7                    
-scikit-learn              1.3.2                    
-scipy                     1.10.1                   
-torch                     1.13.1                   
-torchaudio                0.13.1                   
 ```
 
 ### Contribution

--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ The code to train source separation models on the WSJ0-mix dataset is available 
 - `config_dprnn.py`: configuration file for DPRNN with each configuration for the experiments conducted in the paper.
 - `config_sudo.py`: same with SudoRm-Rf 
 
+### Environment
+
+To install the dependencies, please use the following commands:
+```
+conda create -n annealed_mcl python=3.8
+conda activate annealed_mcl
+conda install pytorch==2.0.0 pytorch-cuda==11.7 -c pytorch -c nvidia -y
+pip install -r requirements.txt
+```
+
+### Data preparation
+
+Metadata for the WJS0-mix dataset are provided. In order to reproduce our experiments, download the wsj0-mix dataset from the [official WSJ0 website](https://catalog.ldc.upenn.edu/LDC93S6A). Once you have access to the WSJ0 data, you can generate the mixtures using the tools provided in [this repository](https://github.com/kaituoxu/Conv-TasNet) (see the "Usage" section in the README). We provide the metadata for mixtures from 2 to 5 speakers at the following [url](https://drive.google.com/drive/folders/1i4S17O5h-k5YNCtoOj53osuzgDNYH6pN?usp=sharing). Download the `data` folder from this url and place in the `./source_separation` folder. 
+
+Finally, update the downloaded metadata audio path to specify the root folder of the WSJ0-mix dataset with the following command:
+```
+python update_metadata.py /wsj0-mix/root/path
+```
+
 ### Training model with a given configuration
 
 To train a model:

--- a/source_separation/config_dprnn.py
+++ b/source_separation/config_dprnn.py
@@ -17,9 +17,9 @@ cluster = socket.gethostname()
 slurm = "SLURM_JOB_ID" in os.environ
 
 # place to save the logs (tb logs)
-log_dir_path = "/path/to/log/dir/"
+log_dir_path = "./log"
 # data directory with the CSV files to generate the mixtures
-data_dir_path = "/path/to/data/dir/"
+data_dir_path = "./data"
 
 # Data setup as a function of number of sources and sample rate
 n_src=2 #maximum number of sources to separate. If n_src=3 it will train on wsj0{2-3}mix

--- a/source_separation/config_sudo.py
+++ b/source_separation/config_sudo.py
@@ -15,11 +15,11 @@ EXP = "001"
 
 cluster = socket.gethostname()
 slurm = "SLURM_JOB_ID" in os.environ
-log_dir_path = "/path/to/log/dir/"
+
+# place to save the logs (tb logs)
+log_dir_path = "./log"
 # data directory with the CSV files to generate the mixtures
-data_dir_path = "/path/to/data/dir/"
-#if "audible01" in cluster:
-#  data_dir_path = "/data/"
+data_dir_path = "./data"
 
 # Data setup as a function of number of sources and sample rate
 n_src=2 #maximum number of sources to separate. If n_src=3 it will train on wsj0{2-3}mix

--- a/source_separation/requirements.txt
+++ b/source_separation/requirements.txt
@@ -1,0 +1,3 @@
+asteroid==0.7.0
+tensorboard==2.12.1
+pot>=0.9.3

--- a/source_separation/train.py
+++ b/source_separation/train.py
@@ -48,7 +48,7 @@ parser.add_argument("--conf_id", default="001",
 parser.add_argument("--debug", type=bool, default=False,
           help="If true save to specific directory")
 parser.add_argument("--ckpt",default=None,type=str,help="Path to the checkpoint from which to start the training ('last' or specific path)")
-parser.add_argument("--backbone", default="sudo", choices=["sudo","dprnn"],type=str)
+parser.add_argument("--backbone", default="dprnn", choices=["sudo","dprnn"],type=str)
 def main(conf):
 
   conf_id = conf["conf_id"]

--- a/source_separation/update_metadata.py
+++ b/source_separation/update_metadata.py
@@ -1,0 +1,20 @@
+import pandas as pd 
+import argparse
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root",default=None,type=str,help="Path to the root of the wsj0 dataset. Use \"\" to reset to original metadata.")
+    args = parser.parse_args()
+    root = args.root.rstrip("/") 
+
+    # Change root path of metadata
+    for partition_name in ["tr", "cv", "tt"]:
+        for min_n_speaker, max_n_speaker in [(2, 2), (2, 3), (2, 4), (2, 5), (3, 3), (4, 4), (5, 5)]:
+            csv_path = f"./data/var_num_speakers/wav8k/min/metadata/{partition_name}/{min_n_speaker}_{max_n_speaker}.csv"
+            df = pd.read_csv(csv_path, index_col=0)
+            path_start = f"{max_n_speaker}speakers"
+            new_path_start = f"{root}/{path_start}" if root else path_start
+            df["mix"] = df["mix"].apply(lambda x: f"{new_path_start}{x.split(path_start)[1]}" if type(x)==str and  path_start in x else float("nan"))
+            for n_speaker in range(1, max_n_speaker+1):
+                df[f"s{n_speaker}"] = df[f"s{n_speaker}"].apply(lambda x: f"{new_path_start}{x.split(path_start)[1]}" if type(x)==str and path_start in x else float("nan"))
+            df.to_csv(csv_path)

--- a/source_separation/update_metadata.py
+++ b/source_separation/update_metadata.py
@@ -1,3 +1,8 @@
+"""
+This script can be used to update the path in the metadata of the WSJ0-mix dataset.
+It can be used as follows:
+python update_metadata.py /wsj0-mix/root/path
+"""
 import pandas as pd 
 import argparse
 


### PR DESCRIPTION
Fix issue [#1](https://github.com/Victorletzelter/annealed_mcl/issues/1)

This pull request introduces the following updates.

- Adding metadata for the WSJ0-mix dataset and a script to update the root path of the dataset within the metadata files. Instructions are added in the README file indicating how to use this script.
- Adding instructions in the README file to replicate the conda environment used for the source separation experiments.
- Set the default source separation backbone to DPRNN instead of Sudo-rm-rf.